### PR TITLE
fix #32; includeBandwidths=0 for iOS support

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -97,7 +97,8 @@ def CreateChannelObject(
         fmt,
         bitrate,
         thumb,
-        include_container=False
+        include_container=False,
+        includeBandwidths=0
     ):
     """Build yon streamable object, ye mighty."""
 


### PR DESCRIPTION
This addresses #32. I can confirm that iOS playback is functional on my iPad at least. :)

This also appears to fix an unreported playback bug on Plex for Samsung (that I just noticed this morning), so that's nice!